### PR TITLE
Update settings.php

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -14,19 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Data to control defaults when creating and running a question
+ * Data to control defaults when creating and running this plugin
  *
  * @package    report_componentgrades
- * @copyright  2021 Marcus Green
+ * @copyright  2021 Dianne Dhanassar <dianne.dhanassar@my.uwi.edu>
+ * @copyright  based on work by 2014 Paul Nicholls and 2018 Marcus Green
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 defined('MOODLE_INTERNAL') || die;
 
 if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox(
-        'report_componentgrades/showstudentid',
+        'report_componentgrades/showgroups',
+        get_string('showgroups', 'report_componentgrades'),
+        get_string('showgroups_desc', 'report_componentgrades'),
+        0
+    ));
+
+    $settings->add(new admin_setting_configcheckbox(
+        'csvreport_componentgrades/showstudentid',
         get_string('showstudentid', 'report_componentgrades'),
         get_string('showstudentid_text', 'report_componentgrades'),
-        0
+        1
     ));
 }


### PR DESCRIPTION
This code changes the default settings to create a user-friendly plugin. It sets the default for 'show student ID' to yes and 'show groups' to no. The initial code gives an error in the results; the word "empty" was generated under the score column.

I ran some tests on this plugin in Moodle, version 3.9 and 3.11. The default settings generated the error in the results.

Test 1: When the default settings are used, the results are generated with the word "empty" placed under the score column.

Test 2: As the 'show group' checkbox is checked by default, I checked the 'show student ID' checkbox and continued the installation. However, the plugin generated the same result.

Test 3: I checked the 'show student ID' checkbox and unchecked the 'show groups' checkbox. These settings generated the expected results.

This plugin is also generating errors with the 'show group', which I don't have code to fix. However, the code is a quick fix for the results to be generated as expected. 